### PR TITLE
Ammo Belt - No longer highlight errata

### DIFF
--- a/dbJSON/set/SoR.json
+++ b/dbJSON/set/SoR.json
@@ -3241,7 +3241,7 @@
         "position": 141,
         "rarity_code": "C",
         "set_code": "SoR",
-        "text": "Before a weapon upgrade on attached character would be discarded by a card effect, you may discard this upgrade instead.",
+        "text": "Before a <b>weapon</b> upgrade on attached character would be discarded by a card effect, you may discard this upgrade instead.",
         "ttscardid": "2400",
         "type_code": "upgrade"
     },

--- a/dbJSON/set/SoR.json
+++ b/dbJSON/set/SoR.json
@@ -3241,7 +3241,7 @@
         "position": 141,
         "rarity_code": "C",
         "set_code": "SoR",
-        "text": "Before a <i>weapon</i> upgrade on attached character would be discarded by a card effect, you may discard this upgrade instead.",
+        "text": "Before a weapon upgrade on attached character would be discarded by a card effect, you may discard this upgrade instead.",
         "ttscardid": "2400",
         "type_code": "upgrade"
     },


### PR DESCRIPTION
Removed the bold/italic for the word "weapon" (which is an errata) as the DB should not highlight errata.